### PR TITLE
Update run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # how-big-is-jetpack
 How big is Jetpack?
 
-Get started with `php bin/build-json.php`
+# Running the tool
+
+1. Install `cloc` - `brew install cloc`
+2. `php bin/build-json.php prod`


### PR DESCRIPTION
There was a parameter missing from the instructions. Also wasn't mentioned that you need to install `cloc` beforehand.