### PR TITLE
Add a workaround for broken data

### DIFF
--- a/charts/charts.js
+++ b/charts/charts.js
@@ -242,6 +242,14 @@ jQuery( document ).ready( function ( $ ) {
 			if ( versionNum < from || versionNum > to ) {
 				return;
 			}
+			
+			if ( ! release.SUM ) {
+				// Skip releases without proper SUM property
+				// Sometimes this property is missing due to bad data
+				// And breaks the whole page.
+				return;
+			}
+			
 			labels.push( versionNum );
 			filteredData.push( release );
 		} );


### PR DESCRIPTION
One of the releases that got downloaded locally failed because of missing `SUM` property for the release.

This PR adds a workaround in the frontend to just skip those releases.